### PR TITLE
Revert "Bump sidekiq-unique-jobs from 7.1.2 to 7.1.4 (#16535)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -568,7 +568,7 @@ GEM
       sidekiq (>= 3)
       thwait
       tilt (>= 1.4.0)
-    sidekiq-unique-jobs (7.1.4)
+    sidekiq-unique-jobs (7.1.2)
       brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 5.0, < 7.0)


### PR DESCRIPTION
This reverts commit 4fd40ec8947dbc0cc4ca7cce234e2bd5264f63ad.