### PR TITLE
update labeling and version

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
-  "name": "Mastodon",
+  "name": "C4 Mastodon",
   "description": "A GNU Social-compatible microblogging server",
-  "repository": "https://github.com/mastodon/mastodon",
+  "repository": "https://github.com/weex/mastodon",
   "logo": "https://github.com/mastodon.png",
   "env": {
     "HEROKU": {

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
-  "name": "C4 Mastodon",
-  "description": "A GNU Social-compatible microblogging server",
+  "name": "Mastodon",
+  "description": "C4 fork of a GNU Social-compatible microblogging server",
   "repository": "https://github.com/weex/mastodon",
   "logo": "https://github.com/mastodon.png",
   "env": {

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,8 +2,8 @@
 
 lock '3.16.0'
 
-set :repo_url, ENV.fetch('REPO', 'https://github.com/mastodon/mastodon.git')
-set :branch, ENV.fetch('BRANCH', 'master')
+set :repo_url, ENV.fetch('REPO', 'https://github.com/weex/mastodon.git')
+set :branch, ENV.fetch('BRANCH', 'c4')
 
 set :application, 'mastodon'
 set :rbenv_type, :user

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -13,7 +13,7 @@ module Mastodon
     end
 
     def patch
-      1
+      9001
     end
 
     def flags
@@ -33,7 +33,7 @@ module Mastodon
     end
 
     def repository
-      ENV.fetch('GITHUB_REPOSITORY', 'mastodon/mastodon')
+      ENV.fetch('GITHUB_REPOSITORY', 'weex/mastodon')
     end
 
     def source_base_url

--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-REPOSITORY_NAME = 'mastodon/mastodon'
+REPOSITORY_NAME = 'weex/mastodon'
 
 namespace :repo do
   desc 'Generate the AUTHORS.md file'
@@ -34,7 +34,7 @@ namespace :repo do
 
     file << <<~FOOTER
 
-      This document is provided for informational purposes only. Since it is only updated once per release, the version you are looking at may be currently out of date. To see the full list of contributors, consider looking at the [git history](https://github.com/mastodon/mastodon/graphs/contributors) instead.
+      This document is provided for informational purposes only. Since it is only updated periodically, the version you are looking at may be currently out of date. To see the full list of contributors, consider looking at the [git history](https://github.com/weex/mastodon/graphs/contributors) instead.
     FOOTER
   end
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mastodon/mastodon",
+  "name": "@weex/mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": ">=12"
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mastodon/mastodon.git"
+    "url": "https://github.com/weex/mastodon.git"
   },
   "browserslist": [
     "last 2 versions",

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -91,8 +91,8 @@ describe InstancePresenter do
   end
 
   describe '#source_url' do
-    it 'returns "https://github.com/mastodon/mastodon"' do
-      expect(instance_presenter.source_url).to eq('https://github.com/mastodon/mastodon')
+    it 'returns "https://github.com/weex/mastodon"' do
+      expect(instance_presenter.source_url).to eq('https://github.com/weex/mastodon')
     end
   end
 


### PR DESCRIPTION
Change patch version to 9001 so it's clearly out of the normal realm of patch numbers.

Helps with #109 but not a full solution.

Fixes #143